### PR TITLE
Improve page navigation performance and reduce unnecessary refetching

### DIFF
--- a/FamilySync/src/boot/vueQuery.test.ts
+++ b/FamilySync/src/boot/vueQuery.test.ts
@@ -1,0 +1,20 @@
+import { describe, test, expect, vi } from 'vitest';
+import type { QueryClient } from '@tanstack/vue-query';
+import vueQueryBoot from './vueQuery';
+
+describe('vueQuery boot', () => {
+  test('configures the QueryClient with a non-zero staleTime and gcTime', () => {
+    const use = vi.fn();
+    void vueQueryBoot({ app: { use } } as never);
+
+    expect(use).toHaveBeenCalledTimes(1);
+    const [, { queryClient }] = use.mock.calls[0] as [unknown, { queryClient: QueryClient }];
+
+    const defaults = queryClient.getDefaultOptions().queries;
+    // A non-zero staleTime means a page revisited shortly after mount reuses
+    // cached data instead of firing a fresh request (and MSAL token round trip)
+    // on every navigation.
+    expect(defaults?.staleTime).toBeGreaterThan(0);
+    expect(defaults?.gcTime).toBeGreaterThan(0);
+  });
+});

--- a/FamilySync/src/boot/vueQuery.ts
+++ b/FamilySync/src/boot/vueQuery.ts
@@ -2,7 +2,14 @@ import { boot } from 'quasar/wrappers'
 import { VueQueryPlugin, QueryClient } from '@tanstack/vue-query'
 
 export default boot(({ app }) => {
-  const queryClient = new QueryClient()
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60_000,
+        gcTime: 5 * 60_000,
+      },
+    },
+  })
 
   app.use(VueQueryPlugin, {
     queryClient,

--- a/FamilySync/src/components/AuthButton.vue
+++ b/FamilySync/src/components/AuthButton.vue
@@ -21,6 +21,7 @@ import { useRouter } from 'vue-router';
 import type { AccountInfo } from '@azure/msal-browser';
 import { useI18n } from 'vue-i18n';
 import { loginRequest } from 'src/boot/msal';
+import { clearCachedAccessToken } from 'src/utils/getAccessToken';
 
 const { t } = useI18n();
 const { appContext } = getCurrentInstance()!;
@@ -33,6 +34,7 @@ const login = () => {
   void msal.loginRedirect(loginRequest);
 };
 const logout = () => {
+  clearCachedAccessToken();
   void msal.logoutRedirect();
 };
 

--- a/FamilySync/src/components/pageLayoutBuildingBlocks/LoadingAnimation.vue
+++ b/FamilySync/src/components/pageLayoutBuildingBlocks/LoadingAnimation.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="column items-center justify-center q-gutter-sm">
     <q-spinner color="teal" size="50px" />
-    <text-h4>Loading</text-h4>
+    <div class="text-h4">Loading</div>
   </div>
 </template>

--- a/FamilySync/src/components/pageLayoutBuildingBlocks/LoadingAnimation.vue
+++ b/FamilySync/src/components/pageLayoutBuildingBlocks/LoadingAnimation.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="column items-center justify-center q-gutter-sm">
     <q-spinner color="teal" size="50px" />
-    <div class="text-h4">Loading</div>
+    <div class="text-h6">Loading</div>
   </div>
 </template>

--- a/FamilySync/src/router/routes.test.ts
+++ b/FamilySync/src/router/routes.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from 'vitest';
+import routes, { PATHS } from './routes';
+
+describe('routes', () => {
+  test('mounts MainLayout once as a shared parent for every page', () => {
+    // Regression guard: previously each page path had its own top-level route
+    // pointing at MainLayout.vue, so Vue Router treated navigation between pages
+    // as a full layout remount instead of reusing one persistent app shell.
+    const mainLayoutRoutes = routes.filter(
+      (route) => route.path !== '/:catchAll(.*)*',
+    );
+
+    expect(mainLayoutRoutes).toHaveLength(1);
+
+    const [mainRoute] = mainLayoutRoutes;
+    const childPaths = mainRoute?.children?.map((child) => child.path) ?? [];
+
+    expect(childPaths).toEqual(
+      expect.arrayContaining([
+        PATHS.HOME,
+        PATHS.CALENDAR,
+        PATHS.SHOPPING_LIST,
+        PATHS.TODO_LIST,
+        PATHS.SETTINGS,
+      ]),
+    );
+  });
+
+  test('keeps the catch-all route outside the shared layout', () => {
+    const catchAll = routes.find((route) => route.path === '/:catchAll(.*)*');
+    expect(catchAll).toBeDefined();
+  });
+});

--- a/FamilySync/src/router/routes.ts
+++ b/FamilySync/src/router/routes.ts
@@ -28,29 +28,18 @@ export const PATHS = {
 
 const routes: RouteRecordRaw[] = [
   {
-    path: PATHS.HOME,
+    path: '/',
     component: () => import('layouts/MainLayout.vue'),
-    children: [{ path: '', component: () => import('pages/HomePage.vue') }],
-  },
-  {
-    path: PATHS.CALENDAR,
-    component: () => import('layouts/MainLayout.vue'),
-    children: [{ path: '', component: () => import('pages/calendar/CalendarPage.vue') }],
-  },
-  {
-    path: PATHS.SHOPPING_LIST,
-    component: () => import('layouts/MainLayout.vue'),
-    children: [{ path: '', component: () => import('src/pages/shoppingList/ShoppingListPage.vue') }],
-  },
-  {
-    path: PATHS.TODO_LIST,
-    component: () => import('layouts/MainLayout.vue'),
-    children: [{ path: '', component: () => import('src/pages/todoList/TodoListPage.vue') }],
-  },
-  {
-    path: PATHS.SETTINGS,
-    component: () => import('layouts/MainLayout.vue'),
-    children: [{ path: '', component: () => import('pages/settings/SettingsPage.vue') }],
+    children: [
+      { path: PATHS.HOME, component: () => import('pages/HomePage.vue') },
+      { path: PATHS.CALENDAR, component: () => import('pages/calendar/CalendarPage.vue') },
+      {
+        path: PATHS.SHOPPING_LIST,
+        component: () => import('src/pages/shoppingList/ShoppingListPage.vue'),
+      },
+      { path: PATHS.TODO_LIST, component: () => import('src/pages/todoList/TodoListPage.vue') },
+      { path: PATHS.SETTINGS, component: () => import('pages/settings/SettingsPage.vue') },
+    ],
   },
   {
     path: '/:catchAll(.*)*',

--- a/FamilySync/src/utils/getAccessToken.test.ts
+++ b/FamilySync/src/utils/getAccessToken.test.ts
@@ -1,0 +1,71 @@
+/* eslint-disable @typescript-eslint/unbound-method -- msalInstance is a plain mock object of vi.fn()s, not a class instance with `this` binding */
+import 'src/tests/mocks/msal.mock';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { msalInstance } from 'src/boot/msal';
+import { getAccessToken, clearCachedAccessToken } from './getAccessToken';
+
+describe('getAccessToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearCachedAccessToken();
+  });
+
+  test('returns null and skips MSAL when there is no account', async () => {
+    vi.mocked(msalInstance.getActiveAccount).mockReturnValue(null);
+    vi.mocked(msalInstance.getAllAccounts).mockReturnValue([]);
+
+    const token = await getAccessToken();
+
+    expect(token).toBeNull();
+    expect(msalInstance.acquireTokenSilent).not.toHaveBeenCalled();
+  });
+
+  test('reuses a cached token instead of calling MSAL again while it is still valid', async () => {
+    vi.mocked(msalInstance.getActiveAccount).mockReturnValue({} as never);
+    vi.mocked(msalInstance.acquireTokenSilent).mockResolvedValue({
+      accessToken: 'token-1',
+      expiresOn: new Date(Date.now() + 10 * 60_000),
+    } as never);
+
+    const first = await getAccessToken();
+    const second = await getAccessToken();
+
+    expect(first).toBe('token-1');
+    expect(second).toBe('token-1');
+    expect(msalInstance.acquireTokenSilent).toHaveBeenCalledTimes(1);
+  });
+
+  test('re-acquires once the cached token is expired', async () => {
+    vi.mocked(msalInstance.getActiveAccount).mockReturnValue({} as never);
+    vi.mocked(msalInstance.acquireTokenSilent)
+      .mockResolvedValueOnce({
+        accessToken: 'token-1',
+        expiresOn: new Date(Date.now() - 1),
+      } as never)
+      .mockResolvedValueOnce({
+        accessToken: 'token-2',
+        expiresOn: new Date(Date.now() + 10 * 60_000),
+      } as never);
+
+    const first = await getAccessToken();
+    const second = await getAccessToken();
+
+    expect(first).toBe('token-1');
+    expect(second).toBe('token-2');
+    expect(msalInstance.acquireTokenSilent).toHaveBeenCalledTimes(2);
+  });
+
+  test('clearCachedAccessToken forces a fresh acquisition on the next call', async () => {
+    vi.mocked(msalInstance.getActiveAccount).mockReturnValue({} as never);
+    vi.mocked(msalInstance.acquireTokenSilent).mockResolvedValue({
+      accessToken: 'token-1',
+      expiresOn: new Date(Date.now() + 10 * 60_000),
+    } as never);
+
+    await getAccessToken();
+    clearCachedAccessToken();
+    await getAccessToken();
+
+    expect(msalInstance.acquireTokenSilent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/FamilySync/src/utils/getAccessToken.ts
+++ b/FamilySync/src/utils/getAccessToken.ts
@@ -1,6 +1,18 @@
 import { msalInstance } from 'src/boot/msal';
 
+// Cached in-memory so repeated queries on the same page (or across pages within
+// the token's lifetime) don't each pay for a round trip through MSAL's own cache.
+let cachedToken: string | null = null;
+let cachedTokenExpiresOn = 0;
+
+// Refresh a bit before the real expiry so we never hand out a token that expires mid-request.
+const EXPIRY_BUFFER_MS = 60_000;
+
 export async function getAccessToken(): Promise<string | null> {
+  if (cachedToken && Date.now() < cachedTokenExpiresOn - EXPIRY_BUFFER_MS) {
+    return cachedToken;
+  }
+
   const account = msalInstance.getActiveAccount() || msalInstance.getAllAccounts()[0];
 
   if (!account) {
@@ -14,9 +26,18 @@ export async function getAccessToken(): Promise<string | null> {
       scopes: [`api://${import.meta.env.VITE_AZURE_CLIENT_ID}/access_as_user`]
     });
 
-    return response.accessToken;
+    cachedToken = response.accessToken;
+    cachedTokenExpiresOn = response.expiresOn?.getTime() ?? Date.now() + EXPIRY_BUFFER_MS;
+
+    return cachedToken;
   } catch (error) {
     console.error('Failed to acquire access token silently', error);
     return null;
   }
+}
+
+// Call on logout / account switch so a token for the previous account is never reused.
+export function clearCachedAccessToken(): void {
+  cachedToken = null;
+  cachedTokenExpiresOn = 0;
 }

--- a/FamilySync/vitest.config.ts
+++ b/FamilySync/vitest.config.ts
@@ -5,9 +5,13 @@ import path from 'path';
 export default defineConfig({
   plugins: [vue()],
   resolve: {
-    alias: {
-      'src': path.resolve(__dirname, './src'),
-    },
+    alias: [
+      { find: 'src', replacement: path.resolve(__dirname, './src') },
+      // Mirrors the "layouts"/"pages" aliases @quasar/app-vite sets up for the real
+      // build, needed here because routes.ts references them as bare specifiers.
+      { find: 'layouts', replacement: path.resolve(__dirname, './src/layouts') },
+      { find: 'pages', replacement: path.resolve(__dirname, './src/pages') },
+    ],
   },
   test: {
     globals: true,


### PR DESCRIPTION
## Summary

This PR improves page navigation performance and reduces unnecessary network requests.

Previously, every route navigation caused `MainLayout` to be remounted, which triggered Vue Query refetches and repeated MSAL token acquisition calls. This resulted in slower page transitions and unnecessary API requests.

## Changes

- Restructured the router so all pages share a single `MainLayout` instance.
- Added default caching to Vue Query:
  - `staleTime: 60s`
  - `gcTime: 5min`
- Added in-memory caching for MSAL access tokens with expiration handling.
- Cleared the cached token on logout to avoid reusing tokens from previous sessions.
- Fixed the loading animation styling.
- Added test coverage for:
  - Route structure
  - Vue Query defaults
  - Token caching and invalidation behavior

## Expected improvements

- Faster page navigation
- Fewer API requests
- Fewer MSAL token round trips
- Improved user experience

## Testing

- [x] Verified that navigation between pages is faster.
- [x] Verified that data is loaded from cache when revisiting pages.
- [x] Verified that logout clears the cached token.
- [x] Verified that the loading animation still works as expected.
- [x] All tests pass.

## Motivation

Page navigation felt slower than expected because the application remounted the entire layout and refetched data on every route change. This PR introduces caching and route restructuring to improve responsiveness.

## Notes

This PR focuses on improving the overall user experience by reducing unnecessary remounts, API requests, and authentication round trips.